### PR TITLE
Avoid copying MKL source into 2decomp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ FFLAGS += $(MODFLAG)$(DECOMPINC) -I$(DECOMPINC)
 SRCDECOMP := $(SRCDECOMP) fft_$(FFT).f90
 SRCDECOMP_ = $(patsubst %.f90,$(SRCDIR)/%.f90,$(filter-out %/mkl_dfti.f90,$(SRCDECOMP)))
 SRCDECOMP_ += $(filter %/mkl_dfti.f90,$(SRCDECOMP))
-OBJDECOMP_MKL := $(patsubst $(MKLROOT)/include/%.f90,$(OBJDIR)/%.f90,$(filter %/mkl_dfti.f90,$(SRCDECOMP_)))
-OBJDECOMP_MKL := $(subst %.f90,%.o,$(OBJDECOMP_MKL))
+OBJDECOMP_MKL_ = $(patsubst $(MKLROOT)/include/%.f90,$(OBJDIR)/%.f90,$(filter %/mkl_dfti.f90,$(SRCDECOMP_)))
+OBJDECOMP_MKL = $(OBJDECOMP_MKL_:%.f90=%.o)
 OBJDECOMP = $(SRCDECOMP_:$(SRCDIR)/%.f90=$(OBJDIR)/%.o)
 
 OPT += $(OPTIO)
@@ -127,7 +127,7 @@ $(OBJDECOMP) : $(OBJDIR)/%.o : $(SRCDIR)/%.f90
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@
 
 $(OBJDECOMP_MKL) : $(OBJDIR)/%.o : $(MKLROOT)/include/%.f90
-	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $(MKLROOT)/include/mkl_dfti.f90 -o $@
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $(MKLROOT)/include/mkl_dfti.f90 -o $(OBJDIR)/mkl_dfti.o
 
 examples: $(LIBDECOMP)
 	$(MAKE) -C examples

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,6 @@ $(OBJDECOMP) : $(OBJDIR)/%.o : $(SRCDIR)/%.f90
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@
 
 $(OBJDECOMP_MKL) : $(OBJDIR)/%.o : $(MKLROOT)/include/%.f90
-	$(info "HI" $< $@ $(MKLROOT))
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $(MKLROOT)/include/mkl_dfti.f90 -o $@
 
 examples: $(LIBDECOMP)

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ else ifeq ($(FFT),generic)
   INC=
   LIBFFT=
 else ifeq ($(FFT),mkl)
-  $(shell cp $(MKLROOT)/include/mkl_dfti.f90 ./src/) # FIXME This is broken in CI
-  SRCDECOMP += mkl_dfti.f90
+  SRCDECOMP += $(MKLROOT)/include/mkl_dfti.f90
   LIBFFT=-Wl,--start-group $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a $(MKLROOT)/lib/intel64/libmkl_sequential.a $(MKLROOT)/lib/intel64/libmkl_core.a -Wl,--end-group -lpthread
   INC=-I$(MKLROOT)/include
 else ifeq ($(FFT),cufft)
@@ -88,10 +87,6 @@ ifeq ($(PROFILER),caliper)
   LFLAGS := $(LFLAGS) -L$(CALIPER_PATH)/lib -lcaliper
 endif
 
-SRCDECOMP := $(SRCDECOMP) fft_$(FFT).f90
-SRCDECOMP_ = $(patsubst %.f90,$(SRCDIR)/%.f90,$(SRCDECOMP))
-OBJDECOMP = $(SRCDECOMP_:$(SRCDIR)/%.f90=$(OBJDIR)/%.o)
-
 #######OPTIONS settings###########
 OPT =
 LINKOPT = $(FFLAGS)
@@ -102,6 +97,13 @@ OBJDIR = obj
 SRCDIR = src
 DECOMPINC = mod
 FFLAGS += $(MODFLAG)$(DECOMPINC) -I$(DECOMPINC)
+
+SRCDECOMP := $(SRCDECOMP) fft_$(FFT).f90
+SRCDECOMP_ = $(patsubst %.f90,$(SRCDIR)/%.f90,$(filter-out %/mkl_dfti.f90,$(SRCDECOMP)))
+SRCDECOMP_ += $(filter %/mkl_dfti.f90,$(SRCDECOMP))
+OBJDECOMP_MKL := $(patsubst $(MKLROOT)/include/%.f90,$(OBJDIR)/%.f90,$(filter %/mkl_dfti.f90,$(SRCDECOMP_)))
+OBJDECOMP_MKL := $(subst %.f90,%.o,$(OBJDECOMP_MKL))
+OBJDECOMP = $(SRCDECOMP_:$(SRCDIR)/%.f90=$(OBJDIR)/%.o)
 
 OPT += $(OPTIO)
 INC += $(INCIO)
@@ -115,7 +117,7 @@ $(DECOMPINC):
 
 $(LIBDECOMP) : Makefile.settings lib$(LIBDECOMP).a
 
-lib$(LIBDECOMP).a: $(OBJDECOMP)
+lib$(LIBDECOMP).a: $(OBJDECOMP_MKL) $(OBJDECOMP)
 	$(AR) $(LIBOPT) $@ $^
 
 $(OBJDIR):
@@ -123,6 +125,10 @@ $(OBJDIR):
 
 $(OBJDECOMP) : $(OBJDIR)/%.o : $(SRCDIR)/%.f90
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@
+
+$(OBJDECOMP_MKL) : $(OBJDIR)/%.o : $(MKLROOT)/include/%.f90
+	$(info "HI" $< $@ $(MKLROOT))
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $(MKLROOT)/include/mkl_dfti.f90 -o $@
 
 examples: $(LIBDECOMP)
 	$(MAKE) -C examples

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -32,7 +32,7 @@ module decomp_2d_fft
 
   ! common code used for all engines, including global variables, 
   ! generic interface definitions and several subroutines
-#include "fft_common.inc"
+#include "fft_common.f90"
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !  This routine performs one-time initialisations for the FFT engine


### PR DESCRIPTION
This just points the compiler at MKL source and builds appropriate object file under obj/

Note solution is a *little* hacky as needed to hardcode the filename, but I think it should work.